### PR TITLE
Optimize the arena with Box<str>

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,4 +106,18 @@ mod tests {
         assert_eq!(interner.lookup(id), "hello");
         assert_eq!(interner.try_lookup(id), Some("hello"));
     }
+
+    #[test]
+    fn reallocate() {
+        let mut interner = Intern::with_capacity(1);
+        let id1 = interner.intern("hello");
+
+        // this should reallocate the internal list
+        let id2 = interner.intern("world");
+
+        assert_eq!(interner.lookup(id1), "hello");
+        assert_eq!(interner.try_lookup(id1), Some("hello"));
+        assert_eq!(interner.lookup(id2), "world");
+        assert_eq!(interner.try_lookup(id2), Some("world"));
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,11 @@ impl Intern<'_> {
         let key: *const str = input.as_str();
         let id = self.list.len() as InternId;
         self.list.push(input);
+
+        // SAFETY: we can do this because the allocations inside of a String
+        // are stable, and so passing ownership to push does not change the
+        // address. furthermore, we have no current API that will allow the
+        // strings inside data to be modified, and so they will never reallocate
         self.data.insert(unsafe { &*key }, id);
         id
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,15 +43,16 @@ impl Intern<'_> {
     /// assert_eq!(intern.lookup(id), "hello");
     /// ```
     #[inline]
-    pub fn intern<V: Into<String> + AsRef<str>>(&mut self, input: V) -> InternId {
-        if let Some(&id) = self.data.get(input.as_ref()) {
+    pub fn intern<V: Into<String>>(&mut self, input: V) -> InternId {
+        let input = input.into();
+
+        if let Some(&id) = self.data.get(&*input) {
             return id;
         }
 
-        let owned = input.into();
-        let key: *const str = owned.as_str();
+        let key: *const str = input.as_str();
         let id = self.list.len() as InternId;
-        self.list.push(owned);
+        self.list.push(input);
         self.data.insert(unsafe { &*key }, id);
         id
     }


### PR DESCRIPTION
So, after I convinced myself that the unsafe code in the previous PR is okay, I was talking to @davidbarsky about my uneasiness. He was the one who pointed out that if the `String`s get modified, that would invalidate your pointers, and so that would be an issue. However, since there's no such API, this should be fine.

Thinking about it a moment, I went "oh wait, an owned immutable `String` is a `Box<str>`!" And then @davidbarsky found this post: https://users.rust-lang.org/t/use-case-for-box-str-and-string/8295/4

> As far as I know there is exactly one reason to use Box<str> over String. .... The compiler uses Box<str> as an optimization when it has a massive number of immutable strings so size matters, for example the string interner:

Ha! So my idea was even correct.

However, some bad news for this PR:

```text
~/Documents/GitHub/string_interner> cargo +nightly miri test
Preparing a sysroot for Miri (target: x86_64-pc-windows-msvc)... done
   Compiling intern_string v0.1.0 (C:\Users\steve\Documents\GitHub\string_interner)
    Finished test [unoptimized + debuginfo] target(s) in 0.20s
     Running unittests src\lib.rs (target\miri\x86_64-pc-windows-msvc\debug\deps\intern_string-a3f23e80654146a3.exe)

running 2 tests
error: Undefined Behavior: trying to retag from <105876> for SharedReadOnly permission at alloc27383[0x0], but that tag does not exist in the borrow stack for this location
   --> C:\Users\steve\.rustup\toolchains\nightly-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\core\src\slice\raw.rs:102:9
    |
102 |         &*ptr::slice_from_raw_parts(data, len)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |         |
    |         trying to retag from <105876> for SharedReadOnly permission at alloc27383[0x0], but that tag does not exist in the borrow stack for this location
    |         this error occurs as part of retag at alloc27383[0x0..0x5]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
help: <105876> was created by a SharedReadOnly retag at offsets [0x0..0x5]
   --> src\lib.rs:53:24
    |
53  |         let str_data = input.as_ptr();
    |                        ^^^^^^^^^^^^^^
help: <105876> was later invalidated at offsets [0x0..0x5] by a Unique retag
   --> src\lib.rs:57:24
    |
57  |         self.list.push(input);
    |                        ^^^^^
    = note: BACKTRACE (of the first span):
    = note: inside `std::slice::from_raw_parts::<'_, u8>` at C:\Users\steve\.rustup\toolchains\nightly-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\core\src\slice\raw.rs:102:9: 102:47
note: inside `Intern::<'_>::intern::<&str>`
   --> src\lib.rs:64:52
    |
64  |             unsafe { std::str::from_utf8_unchecked(std::slice::from_raw_parts(str_data, str_len)) };
    |                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: inside `tests::interns_and_handles_lookup`
   --> src\lib.rs:115:18
    |
115 |         let id = interner.intern("hello");
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^
note: inside closure
   --> src\lib.rs:113:36
    |
112 |     #[test]
    |     ------- in this procedural macro expansion
113 |     fn interns_and_handles_lookup() {
    |                                    ^
    = note: this error originates in the attribute macro `test` (in Nightly builds, run with -Z macro-backtrace for more info)

note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

error: aborting due to 1 previous error

test tests::interns_and_handles_lookup ... error: test failed, to rerun pass `--lib`

Caused by:
  process didn't exit successfully: `C:\Users\steve\.rustup\toolchains\nightly-x86_64-pc-windows-msvc\bin\cargo-miri.exe runner C:\Users\steve\Documents\GitHub\string_interner\target\miri\x86_64-pc-windows-msvc\debug\deps\intern_string-a3f23e80654146a3.exe` (exit code: 1)
note: test exited abnormally; to see the full output pass --nocapture to the harness.
```

This is what I was worried about in the previous PR, that there would be some sort of provenance issue.

HOWEVER I also have good news. Just before submitting this PR, I remembered something:

```text
~/Documents/GitHub/string_interner> MIRIFLAGS="-Zmiri-tree-borrows" cargo +nightly miri test
Preparing a sysroot for Miri (target: x86_64-pc-windows-msvc)... done
    Finished test [unoptimized + debuginfo] target(s) in 0.11s
     Running unittests src\lib.rs (target\miri\x86_64-pc-windows-msvc\debug\deps\intern_string-a3f23e80654146a3.exe)

running 2 tests
test tests::interns_and_handles_lookup ... ok
test tests::reallocate ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

   Doc-tests intern_string

running 3 tests
test src\lib.rs - Intern<'_>::lookup (line 78) ... ok
test src\lib.rs - Intern<'_>::try_lookup (line 95) ... ok
test src\lib.rs - Intern<'_>::intern (line 38) ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.18s
```

This checks the code under the newer "tree borrows" mode. This *does* pass without undefined behavior. This, specifically, increases my confidence in the correctness quite a bit. So maybe this part is actually okay, in the end.

Anyway I am sending this in as a separate PR because we should focus on getting #5 merged, and then I will rebase this on top of it, so that we can talk about "fixes to your PR" and "here's an optimization" separately.